### PR TITLE
Initial Security Page

### DIFF
--- a/geoshape/core/context_processors.py
+++ b/geoshape/core/context_processors.py
@@ -3,6 +3,15 @@ from django.utils.translation import ugettext as _
 from geoshape.version import get_version
 
 
+def security(request):
+    """ Pass CLASSIFICATION_LEVEL, DATA_STATEMENTS, and PRIVACY_STATEMENT from settings for security.html template. """
+
+    return dict(
+               CLASSIFICATION_LEVEL=getattr(settings, 'CLASSIFICATION_LEVEL', None),
+               DATA_STATEMENTS=getattr(settings, 'DATA_STATEMENTS', None),
+               PRIVACY_STATEMENT=getattr(settings, 'PRIVACY_STATEMENT', None))
+
+
 def security_warnings(request, PROXY_ALLOWED_HOSTS=()):
     """ Detects insecure settings and reports them to the client-side context. """
 

--- a/geoshape/core/context_processors.py
+++ b/geoshape/core/context_processors.py
@@ -7,9 +7,9 @@ def security(request):
     """ Pass CLASSIFICATION_LEVEL, DATA_STATEMENTS, and PRIVACY_STATEMENT from settings for security.html template. """
 
     return dict(
-               CLASSIFICATION_LEVEL=getattr(settings, 'CLASSIFICATION_LEVEL', None),
-               DATA_STATEMENTS=getattr(settings, 'DATA_STATEMENTS', None),
-               PRIVACY_STATEMENT=getattr(settings, 'PRIVACY_STATEMENT', None))
+        CLASSIFICATION_LEVEL=getattr(settings, 'CLASSIFICATION_LEVEL', None),
+        DATA_STATEMENTS=getattr(settings, 'DATA_STATEMENTS', None),
+        PRIVACY_STATEMENT=getattr(settings, 'PRIVACY_STATEMENT', None))
 
 
 def security_warnings(request, PROXY_ALLOWED_HOSTS=()):

--- a/geoshape/settings.py
+++ b/geoshape/settings.py
@@ -157,6 +157,7 @@ LOGGING = {
 
 TEMPLATE_CONTEXT_PROCESSORS += (
     'django_classification_banner.context_processors.classification',
+    'geoshape.core.context_processors.security',
     'geoshape.core.context_processors.security_warnings',
     'geoshape.core.context_processors.rogue'
 )

--- a/geoshape/templates/security.html
+++ b/geoshape/templates/security.html
@@ -1,0 +1,45 @@
+{% extends "site_base.html" %}
+{% load i18n %}
+{% load static          <br>
+          <br>files %}
+{% load base_tags %}
+
+{% block title %} {% trans "Security" %} - {{ block.super }} {% endblock %}
+
+{% block body_class %}home{% endblock %}
+
+{% block middle %}
+
+  {% block mainbody %}
+  <div class="container">
+    <div class="row">
+      <div class="col-md-6" style="padding:40px;">
+        {% if CLASSIFICATION_LEVEL %}
+          <h4>Highest Classification Level</h4>
+          <div style="margin-left:20px;"><h5>{{ CLASSIFICATION_LEVEL }}</h5></div>
+          <br>
+        {% endif %}
+        {% if DATA_STATEMENTS %}
+          <h4>Data</h4>
+          <div style="margin-left:20px;">
+          {% for statement in DATA_STATEMENTS %}
+            {{ statement }}<br><br>
+          {% endfor %}
+          </div>
+        {% endif %}
+        {% if PRIVACY_STATEMENT %}
+          <h4>Privacy</h4>
+          <div style="margin-left:20px;">{{ PRIVACY_STATEMENT }}</div>
+          <br>
+        {% endif %}
+          <h4>Password Reset</h4>
+          <div style="margin-left:20px;">You can reset your password at the following page: <a href="/account/password/">Password Reset</a></div>
+          <br>
+          <h4>Security Report</h4>
+          <div style="margin-left:20px;">If you believe the system has been compromised, please immediately alert the system administrator using out-of-band communication.</div>
+      </div>
+    </div>
+  </div>
+  {% endblock %}
+
+{% endblock %}

--- a/geoshape/templates/site_base.html
+++ b/geoshape/templates/site_base.html
@@ -18,7 +18,8 @@
         <div class="row">
           <div class="col-md-8 small-text">
             {% trans "Powered by" %} <a href="http://geoshape.org" target="_new">{% trans "GeoSHAPE" %}</a> <em>{% trans "version" %} {{ VERSION }}</em> |
-            <a href="/docs">{% trans "Documentation" %}</a>
+            <a href="/docs">{% trans "Documentation" %}</a> |
+            <a href="/security/">{% trans "Security" %}</a>
           </div>
           <div class="col-md-4 pull-right">
             <label>{% trans "Language" %}</label>

--- a/geoshape/urls.py
+++ b/geoshape/urls.py
@@ -5,6 +5,7 @@ from maploom.geonode.urls import urlpatterns as maploom_urls
 urlpatterns = patterns('',
                        (r'^file-service/', include('geoshape.file_service.urls')),
                        (r'^proxy/', 'geoshape.views.proxy'),
+                       (r'^security/', 'geoshape.views.security'),
                        )
 
 urlpatterns += geonode_url_patterns

--- a/geoshape/views.py
+++ b/geoshape/views.py
@@ -2,6 +2,8 @@ import logging
 from django.conf import settings
 from django.http import HttpResponse
 from django.http.request import validate_host
+from django.shortcuts import render_to_response
+from django.template import RequestContext
 from django.utils.http import is_safe_url
 from httplib import HTTPConnection, HTTPSConnection
 from urlparse import urlsplit
@@ -78,3 +80,7 @@ def proxy(request):
         response['www-authenticate'] = "GeoNode"
 
     return response
+
+
+def security(request, template='security.html'):
+    return render_to_response(template, RequestContext(request, {}))


### PR DESCRIPTION
This PR creates a security template under `/security/` that pulls from: CLASSIFICATION_LEVEL, DATA_STATEMENTS, and PRIVACY_STATEMENT in settings to build a page where users can look up simple security information, such as the classification level, privacy statement, where to reset password, etc.  A link to the page is also added in the footer.  This will simplify managing multiple deployments and custom builds.  Sysadmins do not have to create a security page from scratch, but can just fill in a few key fields in local_settings.py