### PR TITLE
add slack to installed apps

### DIFF
--- a/geoshape/settings.py
+++ b/geoshape/settings.py
@@ -86,6 +86,7 @@ ROOT_URLCONF = 'geoshape.urls'
 
 INSTALLED_APPS = (
     'geonode.contrib.geogig',
+    'geonode.contrib.slack',
     'geoshape.file_service',
     'geoshape.core',
     'django_classification_banner',


### PR DESCRIPTION
Adds slack to installed apps since its in geonode master and there's no way to add to installed apps in local_settings.  Slack integration is by default turned off unless the "SLACK_ENABLED" flag is added to local_settings.