### PR TITLE
CORS support

### DIFF
--- a/geoshape/settings.py
+++ b/geoshape/settings.py
@@ -171,6 +171,7 @@ AUTH_EXEMPT_URLS = ('/file-service/*', '/i18n/setlang/', '/api/tileset/*', '/gss
 if LOCKDOWN_GEONODE:
     MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + ('geonode.security.middleware.LoginRequiredMiddleware',)
 
+CORS_ENABLED = False
 
 MAP_BASELAYERS = [
     {
@@ -256,3 +257,9 @@ MAP_BASELAYERS = [
         "group":"background"
     }
 ]
+
+if CORS_ENABLED:
+    INSTALLED_APPS =  ('corsheaders',) + INSTALLED_APPS
+    MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + ('corsheaders.middleware.CorsMiddleware',)
+    CORS_ORIGIN_ALLOW_ALL = True
+    CORS_ALLOW_METHODS = ('GET',)

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ install_requires = [
         "psycopg2==2.4.5",
         "django-tilebundler==0.1-beta1",
         "django-gsschema==0.1-beta2",
+        "django-cors-headers>=1.1.0",
 ]
 
 tests_requires = [


### PR DESCRIPTION
Adds support for CORS to GeoNode.  Linked to https://github.com/ROGUE-JCTD/rogue-cookbook/issues/47.

If `CORS_ENABLED` is set to `True` in local_settings.py, then `Access-Control-Allow-Origin:*` will be returned for GET requests.  By default `django-cors-headers` does not allow authenticated requests (browser will strip session cookies), so no security implications.

This is important for querying the metadata catalog via csw in the browser on other origins.