### PR TITLE
fix for pep8 E222 and E402 errors in CI

### DIFF
--- a/geoshape/settings.py
+++ b/geoshape/settings.py
@@ -259,7 +259,7 @@ MAP_BASELAYERS = [
 ]
 
 if CORS_ENABLED:
-    INSTALLED_APPS =  ('corsheaders',) + INSTALLED_APPS
+    INSTALLED_APPS = ('corsheaders',) + INSTALLED_APPS
     MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + ('corsheaders.middleware.CorsMiddleware',)
     CORS_ORIGIN_ALLOW_ALL = True
     CORS_ALLOW_METHODS = ('GET',)

--- a/geoshape/wsgi.py
+++ b/geoshape/wsgi.py
@@ -15,12 +15,13 @@ framework.
 """
 import os
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "geoshape.settings")
+from django.core.wsgi import get_wsgi_application
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "geoshape.settings")
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
-from django.core.wsgi import get_wsgi_application
+
 application = get_wsgi_application()
 
 # Apply WSGI middleware here.


### PR DESCRIPTION
geoshape/settings.py:262:21: E222 multiple spaces after operator
geoshape/wsgi.py:23:1: E402 module level import not at top of file